### PR TITLE
feat: :sparkles: set initial color mode to dark

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,8 @@
 import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
 import { ColorModeScript } from '@chakra-ui/react'
+import theme from '../theme'
+
+console.log(theme.config.initialColorMode)
 
 export default class Document extends NextDocument {
   render() {
@@ -8,7 +11,7 @@ export default class Document extends NextDocument {
         <Head />
         <body>
           {/* Make Color mode to persists when you refresh the page. */}
-          <ColorModeScript />
+          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
           <Main />
           <NextScript />
         </body>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,5 @@
 import NextDocument, { Html, Head, Main, NextScript } from 'next/document'
 import { ColorModeScript } from '@chakra-ui/react'
-import theme from '../theme'
 
 export default class Document extends NextDocument {
   render() {
@@ -9,7 +8,7 @@ export default class Document extends NextDocument {
         <Head />
         <body>
           {/* Make Color mode to persists when you refresh the page. */}
-          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+          <ColorModeScript />
           <Main />
           <NextScript />
         </body>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -11,6 +11,7 @@ const breakpoints = createBreakpoints({
 })
 
 const config: ThemeConfig = {
+  initialColorMode: 'dark',
   useSystemColorMode: true,
 }
 


### PR DESCRIPTION
`useSystemColorMode` takes a while before it sets the color mode to the preferred system settings. This leads to a brief flash of the wrong color. As a workaround, we're setting the initial color mode to dark because a dark flash is less jarring for light mode users than a white flash is for dark mode users.

Part of #10